### PR TITLE
refactor(github-pages): update ScalaDoc and Scoverage report paths

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,7 +6,7 @@ name: Deploy Hugo Site, ScalaDoc and Scoverage Report to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: [ main, docs/process ]
+    branches: [ main, docs/website ]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -60,10 +60,10 @@ jobs:
       - name: Generate ScalaDoc
         run: sbt doc && echo "ScalaDoc generation successful" || (echo "ScalaDoc generation failed" && exit 1)
 
-      - name: Move ScalaDoc to docs/public/scaladoc
+      - name: Move ScalaDoc to docs/website/public/scaladoc
         run: |
-          mkdir -p ./docs/public/scaladoc
-          cp -r target/scala-*/api/* ./docs/public/scaladoc
+          mkdir -p ./docs/website/public/scaladoc
+          cp -r target/scala-*/api/* ./docs/website/public/scaladoc
 
       - name: Generate Scoverage Report
         run: |
@@ -71,10 +71,10 @@ jobs:
           sbt clean coverage test
           sbt coverageReport && echo "Scoverage report generation successful" || (echo "Scoverage report generation failed" && exit 1)
 
-      - name: Move Scoverage Report to docs/public/coverage
+      - name: Move Scoverage Report to docs/website/public/coverage
         run: |
-          mkdir -p ./docs/public/coverage
-          cp -r target/scala-*/scoverage-report/* ./docs/public/coverage
+          mkdir -p ./docs/website/public/coverage
+          cp -r target/scala-*/scoverage-report/* ./docs/website/public/coverage
 
       - name: Install Hugo CLI
         run: |

--- a/docs/website/hugo.yaml
+++ b/docs/website/hugo.yaml
@@ -32,22 +32,22 @@ languages:
     menu:
       main:
         - name: Process
-          url: process/
+          url: process
           weight: 1
         - name: Archive
-          url: archives/
+          url: archives
           weight: 5
         - name: Search
-          url: search/
+          url: search
           weight: 10
         - name: Tags
           url: tags/
           weight: 10
         - name: ScalaDoc
-          url: scaladoc/
+          url: scaladoc
           weight: 15
         - name: Coverage
-          url: coverage/
+          url: coverage
           weight: 16
 
 outputs:

--- a/docs/website/hugo.yaml
+++ b/docs/website/hugo.yaml
@@ -41,7 +41,7 @@ languages:
           url: search
           weight: 10
         - name: Tags
-          url: tags/
+          url: tags
           weight: 10
         - name: ScalaDoc
           url: scaladoc

--- a/docs/website/hugo.yaml
+++ b/docs/website/hugo.yaml
@@ -32,10 +32,10 @@ languages:
     menu:
       main:
         - name: Process
-          url: process
+          url: process/
           weight: 1
         - name: Archive
-          url: archives
+          url: archives/
           weight: 5
         - name: Search
           url: search/
@@ -43,8 +43,12 @@ languages:
         - name: Tags
           url: tags/
           weight: 10
-        - name: WiKi
-          url: https://github.com/adityatelange/hugo-PaperMod/wiki/
+        - name: ScalaDoc
+          url: scaladoc/
+          weight: 15
+        - name: Coverage
+          url: coverage/
+          weight: 16
 
 outputs:
   home:


### PR DESCRIPTION
- Changed output directories for ScalaDoc and Scoverage report from `docs/public` to `docs/website/public` to align with new documentation structure.
- Updated corresponding commands in the GitHub Actions workflow for proper file movement.