### PR TITLE
feat(release): add new poster artifact and update report PDF labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,8 +77,13 @@
             },
             {
               "path": ".release-assets/report.pdf",
-              "label": "Project Report PDF",
+              "label": "report.pdf",
               "name": "report-v${nextRelease.version}.pdf"
+            },
+            {
+              "path": ".release-assets/poster.pdf",
+              "label": "poster.pdf",
+              "name": "poster-v${nextRelease.version}.pdf"
             }
           ]
         }


### PR DESCRIPTION
- Updated the label for the existing project report PDF in the release assets.
- Added a new entry for a poster PDF in the release assets with a corresponding label and naming convention.